### PR TITLE
Update CNC Palettes

### DIFF
--- a/mods/gra/rules/civilian.yaml
+++ b/mods/gra/rules/civilian.yaml
@@ -151,15 +151,15 @@ HOSP:
     Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 7c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
     CaptureManager:
     ProximityCapturable:
-        Range: 3c0
+        Range: 1c0
         CaptorTypes: Infantry
-        MustBeClear: False
+        MustBeClear: True
         Sticky: True
         Permanent: False
     Cargo:
@@ -185,15 +185,15 @@ HOSP:
     Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 7c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
     CaptureManager:
     ProximityCapturable:
-        Range: 3c0
+        Range: 1c0
         CaptorTypes: Infantry
-        MustBeClear: False
+        MustBeClear: True
         Sticky: True
         Permanent: False
     Cargo:

--- a/mods/gra/rules/defaults.yaml
+++ b/mods/gra/rules/defaults.yaml
@@ -906,7 +906,7 @@
 		Range: 1c0
     CaptureManager:
     ProximityCapturable:
-        Range: 3c0
+        Range: 1c0
         CaptorTypes: Infantry
         MustBeClear: True
         Sticky: True #Must be true to allow leavivng units in it

--- a/mods/gra/rules/infantry.yaml
+++ b/mods/gra/rules/infantry.yaml
@@ -203,6 +203,9 @@ Rapt:
 	Voiced:
 		VoiceSet: DogVoice
 	-TakeCover:
+    RenderSprites:
+        Image: rapt
+        Palette: playerCNC
     
 E1:
 	Inherits: ^Soldier
@@ -413,6 +416,7 @@ BUTCH:
 		BuildPaletteOrder: 10
 		Prerequisites: ~barracks, ~techlevel.infonly, ~infantry.proles
 		Description: Him smash.
+        IconPalette: playerCNC
 	Selectable:
 		Class: E1
 	Valued:
@@ -442,6 +446,7 @@ BUTCH:
 		RequiresCondition: parachute
     RenderSprites:
         Image: rmbo
+        Palette: playerCNC
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 BMBR:
@@ -765,6 +770,7 @@ STAN:
 		Prerequisites: barracks.upgraded
     RenderSprites:
         Image: C10
+        Palette: playerCNC
 
 SPY:
 	Inherits: ^Soldier

--- a/mods/gra/rules/structures.yaml
+++ b/mods/gra/rules/structures.yaml
@@ -696,6 +696,7 @@ ZAP:
 		BuildPaletteOrder: 80
 		Prerequisites: weap, ~structures.proles, ~techlevel.medium
 		Description: Makes their hair stand up.
+        IconPalette: playerCNC
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -733,6 +734,9 @@ ZAP:
 	ProvidesPrerequisite@buildingname:
     RenderSprites:
         Image: obli
+        Palette: playerCNC
+    WithBuildingBib:
+        Palette: playerCNC
 
 AGUN:
 	Inherits: ^Defense
@@ -1106,6 +1110,7 @@ ARTGUN:
 		BuildPaletteOrder: 70
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Description: Go long.
+        IconPalette: playerCNC
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -1142,7 +1147,9 @@ ARTGUN:
 		UseClassicFacingFudge: True
     RenderSprites:
         Image: atwr
-
+        Palette: playerCNC
+    WithBuildingBib:
+        Palette: playerCNC
 
 FTUR:
 	Inherits: ^Defense
@@ -2053,7 +2060,7 @@ APWR:
 NPWR:
 	Inherits: ^Building
 	Inherits@POWER_OUTAGE: ^DisabledByPowerOutage
-	Inherits@shape: ^3x2Shape
+	Inherits@shape: ^2x2Shape
 	HitShape:
 		TargetableOffsets: -355,-1024,0
 	Buildable:
@@ -2061,6 +2068,7 @@ NPWR:
 		BuildPaletteOrder: 110
 		Prerequisites: dome, ~techlevel.medium, ~structures.proles
 		Description: Provides double the power of\na standard Power Plant.
+        IconPalette: playerCNC
 	Valued:
 		Cost: 3000
 	Tooltip:
@@ -2068,8 +2076,8 @@ NPWR:
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
-		Footprint: xxx Xxx ===
-		Dimensions: 3,3
+		Footprint: xx xx ==
+		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 72,48
@@ -2096,6 +2104,9 @@ NPWR:
 		DamageSource: Killer
     RenderSprites:
         Image: nuk2
+        Palette: playerCNC
+    WithBuildingBib:
+        Palette: playerCNC
 
 STEK:
 	Inherits: ^ScienceBuilding
@@ -2516,6 +2527,7 @@ BIGBRIK:
 		BuildPaletteOrder: 30
 		Prerequisites: fact, ~techlevel.medium, ~structures.proles
 		Description: Keeps the bad guys out.
+        IconPalette: playerCNC
 	Valued:
 		Cost: 600
 	CustomSellValue:
@@ -2536,6 +2548,9 @@ BIGBRIK:
 		Types: concrete
 	WithWallSpriteBody:
 		Type: concrete
+     RenderSprites:
+        Image: bigbrik
+        Palette: playerCNC
         
 CYCL:
 	Inherits: ^Wall

--- a/mods/gra/rules/vehicles.yaml
+++ b/mods/gra/rules/vehicles.yaml
@@ -315,6 +315,7 @@ MM2K:
 		BuildDurationModifier: 50
         BuildLimit: 1
 		Description: Tiberian Sunnnnnnnn!
+        IconPalette: playerCNC
 	Valued:
 		Cost: 8000
 	Tooltip:
@@ -363,6 +364,7 @@ MM2K:
 		DecorationBounds: 44,38,0,-4
     RenderSprites:
         Image: htnk
+        Palette: playerCNC
         
 ARTY:
 	Inherits: ^TrackedVehicle
@@ -556,6 +558,7 @@ HUMVEE:
 		BuildPaletteOrder: 30
 		Prerequisites: ~vehicles.ira, ~techlevel.low
 		Description: Transport that can hold 4 men\nwho can shoot out the doors
+        IconPalette: playerCNC
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -599,6 +602,7 @@ HUMVEE:
 		Prerequisites: vehicles.upgraded
     RenderSprites:
         Image: humvee
+        Palette: playerCNC
     
 
 BUGGY:
@@ -610,6 +614,7 @@ BUGGY:
 		BuildPaletteOrder: 30
 		Prerequisites: ~vehicles.proles, ~techlevel.medium
 		Description: Fast scout & anti-air vehicle.\nShoots rockets 
+        IconPalette: playerCNC
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -655,6 +660,7 @@ BUGGY:
 		Prerequisites: vehicles.upgraded
     RenderSprites:
         Image: msam
+        Palette: playerCNC
         
 APC:
 	Inherits: ^TrackedVehicle
@@ -706,6 +712,7 @@ ARMOR:
 		BuildPaletteOrder: 40
 		Prerequisites: ~vehicles.proles, ~techlevel.low
 		Description: An unbreakable box.
+        IconPalette: playerCNC
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -738,6 +745,7 @@ ARMOR:
 		Prerequisites: vehicles.upgraded
     RenderSprites:
         Image: apcmcv
+        Palette: playerCNC
 
 MNLY:
 	Inherits: ^TrackedVehicle


### PR DESCRIPTION
Shortened capture ranges to make it harder to capture garrisoned units. Cannot completley stop, because garrisoned units are not accounted for in is clear checks